### PR TITLE
Add trim option to export_layers script

### DIFF
--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -15,21 +15,21 @@ if err ~= 0 then return err end
 -- Variable to keep track of the number of layers exported.
 local n_layers = 0
 -- Exports every layer individually.
-local function exportLayers(sprite, root_layer, filename, group_sep, spritesheet)
+local function exportLayers(sprite, root_layer, filename, group_sep, data)
     for _, layer in ipairs(root_layer.layers) do
         local filename = filename
         if layer.isGroup then
             -- Recursive for groups.
             filename = filename:gsub("{layergroups}",
                                      layer.name .. group_sep .. "{layergroups}")
-            exportLayers(sprite, layer, filename, group_sep, spritesheet)
+            exportLayers(sprite, layer, filename, group_sep, data)
         else
             -- Individual layer. Export it.
             layer.isVisible = true
             filename = filename:gsub("{layergroups}", "")
             filename = filename:gsub("{layername}", layer.name)
             os.execute("mkdir \"" .. Dirname(filename) .. "\"")
-            if spritesheet then
+            if data.spritesheet then
                 app.command.ExportSpriteSheet{
                     ui=false,
                     askOverwrite=false,
@@ -45,7 +45,7 @@ local function exportLayers(sprite, root_layer, filename, group_sep, spritesheet
                     borderPadding=0,
                     shapePadding=0,
                     innerPadding=0,
-                    trim=false,
+                    trim=data.trim,
                     extrude=false,
                     openGenerated=false,
                     layer="",
@@ -93,7 +93,19 @@ dlg:slider{id = 'scale', label = 'Export Scale:', min = 1, max = 10, value = 1}
 dlg:check{
     id = "spritesheet",
     label = "Export as spritesheet:",
-    selected = false
+    selected = false,
+    onclick = function()
+        dlg:modify{
+            id = "trim",
+            visible = dlg.data.spritesheet
+        }
+    end
+}
+dlg:check{
+    id = "trim",
+    label = "Trim:",
+    selected = false,
+    visible = false
 }
 dlg:check{id = "save", label = "Save sprite:", selected = false}
 dlg:button{id = "ok", text = "Export"}
@@ -120,7 +132,7 @@ filename = filename:gsub("{groupseparator}", group_sep)
 -- Finally, perform everything.
 Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
 local layers_visibility_data = HideLayers(Sprite)
-exportLayers(Sprite, Sprite, output_path .. filename, group_sep, dlg.data.spritesheet)
+exportLayers(Sprite, Sprite, output_path .. filename, group_sep, dlg.data)
 RestoreLayersVisibility(Sprite, layers_visibility_data)
 Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
 


### PR DESCRIPTION
This was a great resource, thanks for sharing it! I ended up needing to be able to trim sprites as well, which was easy enough. I slightly restructured the arguments of `exportLayers` to take the entire data object collected by the dialog, which should make supporting additional options in the spritesheet export easier. Then I added a `trim` option which is dynamically hidden and shown depending on the value of `spritesheet` since this option has no effect if the user is not exporting in spritesheet mode.

Please feel free to close this if you think it's unnecessary, but figured I'd open the PR in case it helps!