### PR TITLE
Append underscore before frame number

### DIFF
--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -30,7 +30,7 @@ local function exportLayers(sprite, root_layer, filename, group_sep, data)
             -- Individual layer. Export it.
             layer.isVisible = true
             filename = filename:gsub("{layergroups}", "")
-            filename = filename:gsub("{layername}", layer.name)
+            filename = filename:gsub("{layername}", layer.name .. "_")
             os.execute("mkdir \"" .. Dirname(filename) .. "\"")
             if data.spritesheet then
                 app.command.ExportSpriteSheet{


### PR DESCRIPTION
So lets say there is a layer named "walk" with 3 frames, it gets exported currently as walk1.png, walk2.png, walk3.png
Instead, with this PR it will be exported as walk_1.png, walk_2.png, walk_3.png
