### PR TITLE
Demonkiller8973 add trim by grid

### DIFF
--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -8,6 +8,7 @@ Made by Gaspi.
    - Twitter: @_Gaspi
 Further Contributors:
     - Levy E ("StoneLabs")
+    - Demonkiller8973
 --]]
 
 -- Import main.
@@ -56,7 +57,9 @@ local function exportLayers(sprite, root_layer, filename, group_sep, data)
                     borderPadding=0,
                     shapePadding=0,
                     innerPadding=0,
+					trimSprite=data.trimSprite,
                     trim=data.trim,
+					trimByGrid=data.trimByGrid,
                     mergeDuplicates=data.mergeDuplicates,
                     extrude=false,
                     openGenerated=false,
@@ -110,7 +113,7 @@ dlg:check{
     onclick = function()
         -- Show this options only if spritesheet is checked.
         dlg:modify{
-            id = "trim",
+            id = "trimSprite",
             visible = dlg.data.spritesheet
         }
         dlg:modify{
@@ -124,8 +127,20 @@ dlg:check{
     end
 }
 dlg:check{
-    id = "trim",
-    label = "  Trim:",
+    id = "trimSprite",
+    label = "  Trim Sprite:",
+    selected = false,
+    visible = false,
+	onclick = function()
+		dlg:modify{
+            id = "trimByGrid",
+            visible = dlg.data.trimSprite
+        }
+	end
+}
+dlg:check{
+    id = "trimByGrid",
+    label = "  Trim Grid:",
     selected = false,
     visible = false
 }


### PR DESCRIPTION
Added a new option for export layout.
When spritesheet is checked it reveals the "Trim Sprite" box.
When Trim Sprite is checked it reveals the "Trim Grid" box
This allows you to trim each layer by its grid rather than just the sprite.