### PR TITLE
Add layers selection feature

### DIFF
--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -139,8 +139,8 @@ dlg:entry{
 }
 
 -- Local vars for layer displayed names and internal values
-local layerNames = {}
-local layerMap = {}
+local layerNames = { "All Layers" }
+local layerMap = {["All Layers"] = "ALL_LAYERS" }
 
 -- Recursive function to create a list of all layers/groups and sub-layers in groups
 local function addLayers(layerList, prefix)
@@ -166,7 +166,7 @@ dlg:combobox{
     id = 'format',
     label = 'Export Format:',
     option = 'png',
-    options = {'png', 'gif', 'jpg'}
+    options = {'png', 'gif', 'jpg', 'aseprite'}
 }
 dlg:combobox{
     id = 'group_sep',


### PR DESCRIPTION
Add the possibility to export only one layer or one group.

I made this to solve #15 . It does not directly fix the problem (ignoring hidden layers) ; but I prefer to choose which layers/group I want to export.

It will not allow to export multiple layers in different groups.

It fits my needs and seemed easier to develop ☺️