### PR TITLE
Feature: Export By Layers And Tags 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,40 @@
-# Gaspi's Aseprite Scripts
-
-Welcome to my collection of Aseprite Scripts. They all aim to save you time
-doing specific and repetitive tasks. If you find yourself in this situation, you
-can ask me for a commission! Contact below.
+# Fork from Gaspi's AsepriteScript
 
 Please, take a look at the [repo wiki](https://github.com/PKGaspi/AsepriteScripts/wiki)
 to learn more about the scripts.
 
-## Disclaimer
-These scripts were last tested on Aseprite version v1.3.8. It happened before that
-an Aseprite update broke the functionality of these scripts. Please, backup your work 
-before use. If a script doesn't work, please report openning an issue.
+---
 
-## Installation
+## Additional Feature: Export by Layer and Tag
 
-1. Download or clone this repository.
-1. In Aseprite, go to File -> Scripts -> Open Scripts Folder.
-1. Copy the content of this repository's script folder into the opened script
-   folder.
-1. In Aseprite, go to File -> Scripts -> Re-scan Scripts Folder.
+This fork contains a new script, `export_by_layer_and_tag.lua`, designed to automate the asset pipeline for modular and customizable characters.
 
-## Scripts
+### What It Solves
 
-Here is a list with all the current scripts and how to use them:
-- [Export Layers](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Layers)
-- [Export Slices](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Slices)
-- [Export Combinations](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Combinations)
+When creating characters with swappable parts (like different hairstyles, clothes, or weapons), many game engines require each part's animation set to be a distinct file. For example, a `Long Sword` layer might need `Attack.png`, `Idle.png`, and `Block.png` files. Manually exporting these combinations is tedious and error-prone. This script automates that entire process.
 
-Even if some options may look complicated, they are all set in a default value
-so that they work straight away. If you're looking for more advanced and
-specific ways of export, take a look at them.  
+### How It Works
 
-***Note***.- Some of the scripts
-may mark the sprite as unsaved after executing. **NO** changes are made to the
-sprite if it's not indicated by the script description. However, some of the
-trickery involved causes the sprite to appear as modified.
+The "Export Layers by Tag" script iterates through every layer and every tag in your Aseprite file, exporting a unique spritesheet for each combination.
 
+For a file with layers `Hair`, `Body` and tags `Idle`, `Run`, the script will generate:
 
-## About me
-Hey, I'm a Computer Science graduate fascinated by the videogame industry.
-Here are some of my links:
-- Web: [gaspi.games](http://gaspi.games/)
-- Twitter: [@_Gaspi](https://twitter.com/@_Gaspi)
-- Aseprite Community: [Gaspi](https://community.aseprite.org/u/Gaspi/summary)
+```
+Hair-Idle.png
+Hair-Run.png
+Body-Idle.png
+Body-Run.png
+```
+
+This is perfect for workflows involving:
+
+  * **Unity:** Preparing assets for the `SpriteResolver` in the 2D Animation package.
+  * **Godot:** Creating separate `SpriteFrames` resources for `AnimatedSprite` nodes.
+
+### Quick Usage Guide
+
+1.  Run the main script (`main.lua`).
+2.  In the dialog, click the **"Export Layers by Tag"** button.
+3.  Ensure the **"Export each tag as a separate file"** checkbox is checked.
+4.  Use the **File name format** field with `{layername}` and `{tag}` to define your naming convention.
+5.  Click **Export**.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,63 @@
-# Fork from Gaspi's AsepriteScript
+Of course. Here is the complete README file with the new section seamlessly integrated.
+
+I've added a new section called **"Features Added in this Fork"** right after the original `Scripts` section to clearly distinguish your new feature. I also added a non-linked entry to the original list for consistency.
+
+-----
+
+# Gaspi's Aseprite Scripts
+
+Welcome to my collection of Aseprite Scripts. They all aim to save you time
+doing specific and repetitive tasks. If you find yourself in this situation, you
+can ask me for a commission\! Contact below.
 
 Please, take a look at the [repo wiki](https://github.com/PKGaspi/AsepriteScripts/wiki)
 to learn more about the scripts.
 
----
+## Disclaimer
 
-## Additional Feature: Export by Layer and Tag
+These scripts were last tested on Aseprite version v1.3.8. It happened before that
+an Aseprite update broke the functionality of these scripts. Please, backup your work
+before use. If a script doesn't work, please report openning an issue.
+
+## Installation
+
+1.  Download or clone this repository.
+2.  In Aseprite, go to File -\> Scripts -\> Open Scripts Folder.
+3.  Copy the content of this repository's script folder into the opened script
+    folder.
+4.  In Aseprite, go to File -\> Scripts -\> Re-scan Scripts Folder.
+
+## Scripts
+
+Here is a list with all the current scripts and how to use them:
+
+  - [Export Layers](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Layers)
+  - [Export Slices](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Slices)
+  - [Export Combinations](https://github.com/PKGaspi/AsepriteScripts/wiki/Export-Combinations)
+  - Export Layers by Tag *(New in this fork, see below)*
+
+Even if some options may look complicated, they are all set in a default value
+so that they work straight away. If you're looking for more advanced and
+specific ways of export, take a look at them.
+
+***Note***.- Some of the scripts
+may mark the sprite as unsaved after executing. **NO** changes are made to the
+sprite if it's not indicated by the script description. However, some of the
+trickery involved causes the sprite to appear as modified.
+
+## Features Added in this Fork
+
+### Export Layers by Tag
 
 This fork contains a new script, `export_by_layer_and_tag.lua`, designed to automate the asset pipeline for modular and customizable characters.
 
-### What It Solves
+#### What It Solves
 
-When creating characters with swappable parts (like different hairstyles, clothes, or weapons), many game engines require each part's animation set to be a distinct file. For example, a `Long Sword` layer might need `Attack.png`, `Idle.png`, and `Block.png` files. Manually exporting these combinations is tedious and error-prone. This script automates that entire process.
+When creating characters with swappable parts (like different hairstyles or clothes), many game engines require each part's animation set to be a distinct file. For example, a `Long Sword` layer might need `Attack.png`, `Idle.png`, and `Block.png` files. Manually exporting these combinations is tedious and error-prone. This script automates that entire process.
 
-### How It Works
+#### How It Works
 
-The "Export Layers by Tag" script iterates through every layer and every tag in your Aseprite file, exporting a unique spritesheet for each combination.
+The **"Export Layers by Tag"** script iterates through every layer and every tag in your Aseprite file, exporting a unique spritesheet for each combination.
 
 For a file with layers `Hair`, `Body` and tags `Idle`, `Run`, the script will generate:
 
@@ -28,13 +70,29 @@ Body-Run.png
 
 This is perfect for workflows involving:
 
-  * **Unity:** Preparing assets for the `SpriteResolver` in the 2D Animation package.
+  * **Unity:** Preparing assets for the `SpriteResolver` component in the 2D Animation package.
   * **Godot:** Creating separate `SpriteFrames` resources for `AnimatedSprite` nodes.
 
-### Quick Usage Guide
+#### Quick Usage Guide
 
-1.  Run the main script (`main.lua`).
+1.  Run the `main.lua` script (e.g., via `File > Scripts > main`).
 2.  In the dialog, click the **"Export Layers by Tag"** button.
 3.  Ensure the **"Export each tag as a separate file"** checkbox is checked.
 4.  Use the **File name format** field with `{layername}` and `{tag}` to define your naming convention.
 5.  Click **Export**.
+
+## About Me
+I'm an Indie Game Developer making cool games!
+
+  - Web: [Pedro's Website](http://pedrovilasboas.dev)
+  - Twitter: [@pepeups](https://x.com/@pepeups)
+  - LinkedIn: [Pedro Vilas Bôas](https://www.linkedin.com/in/pedro-vilas-bôas/)
+  
+## About Gaspi
+
+Hey, I'm a Computer Science graduate fascinated by the videogame industry.
+Here are some of my links:
+
+  - Web: [gaspi.games](http://gaspi.games/)
+  - Twitter: [@\_Gaspi](https://twitter.com/@_Gaspi)
+  - Aseprite Community: [Gaspi](https://community.aseprite.org/u/Gaspi/summary)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-Of course. Here is the complete README file with the new section seamlessly integrated.
-
-I've added a new section called **"Features Added in this Fork"** right after the original `Scripts` section to clearly distinguish your new feature. I also added a non-linked entry to the original list for consistency.
-
------
-
 # Gaspi's Aseprite Scripts
 
 Welcome to my collection of Aseprite Scripts. They all aim to save you time

--- a/scripts/gaspi/export_by_layer_and_tag.lua
+++ b/scripts/gaspi/export_by_layer_and_tag.lua
@@ -43,7 +43,7 @@ local function exportByLayerAndTag(sprite, root_layer, filename_template, group_
             current_filename_template = current_filename_template:gsub("{layername}", layer.name)
 
             if data.splitByTagFile and #sprite.tags > 0 then
-                -- ## NEW LOGIC: Iterate through each tag and export a file for it. ##
+                -- [ Tags Logic ] Iterate through each tag and export a file for it.
                 for _, tag in ipairs(sprite.tags) do
                     local final_filename = current_filename_template:gsub("{tag}", tag.name)
                     os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
@@ -62,13 +62,13 @@ local function exportByLayerAndTag(sprite, root_layer, filename_template, group_
                         trimByGrid = data.trimByGrid,
                         layer = layer.name, -- Export only the current layer
                         tag = tag.name,     -- Export only the current tag
-                        splitLayers = false, -- We are handling layers manually
-                        splitTags = false    -- We are handling tags manually
+                        splitLayers = false, -- Handling layers manually
+                        splitTags = false    -- Handling tags manually
                     }
                     n_files_exported = n_files_exported + 1
                 end
             else
-                -- ## OLD LOGIC: Export the whole layer as one file. ##
+                -- ## Export the whole layer as one file.
                 local final_filename = current_filename_template:gsub("{tag}", "") -- Remove tag placeholder if not used
                 os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
                 app.command.ExportSpriteSheet{
@@ -101,7 +101,7 @@ end
 -- ## DIALOG ##
 -- ############
 
-local dlg = Dialog("Export by Layer and Tag")
+local dlg = Dialog("Pepeups - Export by Layer and Tag")
 dlg:file{
     id = "directory",
     label = "Output directory:",
@@ -128,7 +128,7 @@ dlg:combobox{
 dlg:slider{id = 'scale', label = 'Export Scale:', min = 1, max = 10, value = 1}
 dlg:separator()
 
--- ## NEW OPTION ##
+-- ## TAGS OPTION ##
 dlg:check{
     id = "splitByTagFile",
     label = "Export each tag as a separate file",
@@ -163,6 +163,7 @@ dlg:combobox{
     options = {'No', 'To Rows', 'To Columns'}
 }
 
+dlg:check{id = "save", label = "Save sprite:", selected = false}
 dlg:button{id = "ok", text = "Export"}
 dlg:button{id = "cancel", text = "Cancel"}
 dlg:show()
@@ -195,6 +196,9 @@ exportByLayerAndTag(Sprite, Sprite, output_path .. filename_template, group_sep,
 
 RestoreLayersVisibility(Sprite, layers_visibility_data)
 Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+
+-- Save the original file if specified
+if dlg.data.save then Sprite:saveAs(dlg.data.directory) end
 
 -- Success dialog.
 local success_dlg = MsgDialog("Success!", "Exported " .. n_files_exported .. " files.")

--- a/scripts/gaspi/export_by_layer_and_tag.lua
+++ b/scripts/gaspi/export_by_layer_and_tag.lua
@@ -17,80 +17,85 @@ Made by Pedro Vilas Bôas.
     - Demonkiller8973
 --]]
 
--- Import main.
+-- Import main to ensure helper functions are available,
+-- allowing this script to be run standalone or as a module.
 local err = dofile("main.lua")
 if err ~= 0 then return err end
 
--- Variable to keep track of the number of files exported.
+-- Variable to keep track of the number of files exported
 local n_files_exported = 0
 
--- Exports every layer individually, with an option to split by tag.
-local function exportByLayerAndTag(sprite, root_layer, filename_template, group_sep, data)
-    for _, layer in ipairs(root_layer.layers) do
-        local current_filename_template = filename_template
+-- Helper function to recursively get a flat list of all non-group layers
+local function getAllLayers(root, group_path, display_path, layers_list)
+    group_path = group_path or ""
+    display_path = display_path or ""
+    layers_list = layers_list or {}
+
+    for i = #root.layers, 1, -1 do
+        local layer = root.layers[i]
         if layer.isGroup then
-            -- Recursive for groups.
-            local previousVisibility = layer.isVisible
-            layer.isVisible = true
-            current_filename_template = current_filename_template:gsub("{layergroups}",
-                                           layer.name .. group_sep .. "{layergroups}")
-            exportByLayerAndTag(sprite, layer, current_filename_template, group_sep, data)
-            layer.isVisible = previousVisibility
+            local next_group_path = layer.name .. "{groupseparator}" .. group_path
+            local next_display_path = layer.name .. " > " .. display_path
+            getAllLayers(layer, next_group_path, next_display_path, layers_list)
         else
-            -- Individual layer. Export it.
+            table.insert(layers_list, {
+                layer = layer,
+                displayName = display_path .. layer.name,
+                groupPath = group_path
+            })
+        end
+    end
+    return layers_list
+end
+
+-- Centralized function to perform the export command for a single, visible layer
+local function performExportForLayer(sprite, layer, final_filename_template, data)
+    if data.splitByTagFile and #sprite.tags > 0 then
+        for _, tag in ipairs(sprite.tags) do
+            local final_filename = final_filename_template:gsub("{tag}", tag.name)
+            os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
+
+            app.command.ExportSpriteSheet{
+                ui = false, askOverwrite = false, type = SpriteSheetType.HORIZONTAL,
+                textureFilename = final_filename, dataFilename = "",
+                borderPadding = 0, shapePadding = 0, innerPadding = 0,
+                trimSprite = data.trimSprite, trim = data.trimCells, trimByGrid = data.trimByGrid,
+                layer = layer.name, tag = tag.name,
+                splitLayers = false, splitTags = false
+            }
+            n_files_exported = n_files_exported + 1
+        end
+    else
+        local final_filename = final_filename_template:gsub("{tag}", "")
+        os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
+        app.command.ExportSpriteSheet{
+            ui=false, askOverwrite=false, type=SpriteSheetType.ROWS,
+            textureFilename = final_filename, dataFilename = RemoveExtension(final_filename) .. ".json",
+            dataFormat = "json-hash", borderPadding = 0, shapePadding = 0, innerPadding = 0,
+            trimSprite = data.trimSprite, trim = data.trimCells, trimByGrid = data.trimByGrid,
+            layer = layer.name, splitLayers = false,
+            splitTags = (data.tagsplit ~= "No")
+        }
+        n_files_exported = n_files_exported + 1
+    end
+end
+
+-- Processes and exports layers based on the user's selection
+local function processAndExportLayers(sprite, filename_template, group_sep, data, flat_layers)
+    for i, item in ipairs(flat_layers) do
+        local should_export = (data.exportMode == "All Layers") or data["export_layer_" .. i]
+        
+        if should_export then
+            local layer = item.layer
             layer.isVisible = true
-            current_filename_template = current_filename_template:gsub("{layergroups}", "")
+            
+            local current_filename_template = filename_template
+            current_filename_template = current_filename_template:gsub("{layergroups}", item.groupPath)
+            current_filename_template = current_filename_template:gsub("{groupseparator}", group_sep)
             current_filename_template = current_filename_template:gsub("{layername}", layer.name)
-
-            if data.splitByTagFile and #sprite.tags > 0 then
-                -- [ Tags Logic ] Iterate through each tag and export a file for it.
-                for _, tag in ipairs(sprite.tags) do
-                    local final_filename = current_filename_template:gsub("{tag}", tag.name)
-                    os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
-
-                    app.command.ExportSpriteSheet{
-                        ui = false,
-                        askOverwrite = false,
-                        type = SpriteSheetType.HORIZONTAL, -- Or ROWS, COLUMNS as per your preference
-                        textureFilename = final_filename,
-                        dataFilename = "", -- No JSON data for this simple export
-                        borderPadding = 0,
-                        shapePadding = 0,
-                        innerPadding = 0,
-                        trimSprite = data.trimSprite,
-                        trim = data.trimCells,
-                        trimByGrid = data.trimByGrid,
-                        layer = layer.name, -- Export only the current layer
-                        tag = tag.name,     -- Export only the current tag
-                        splitLayers = false, -- Handling layers manually
-                        splitTags = false    -- Handling tags manually
-                    }
-                    n_files_exported = n_files_exported + 1
-                end
-            else
-                -- ## Export the whole layer as one file.
-                local final_filename = current_filename_template:gsub("{tag}", "") -- Remove tag placeholder if not used
-                os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
-                app.command.ExportSpriteSheet{
-                    ui=false,
-                    askOverwrite=false,
-                    type=SpriteSheetType.ROWS, -- Default to rows for non-tag-split
-                    textureFilename = final_filename,
-                    dataFilename = RemoveExtension(final_filename) .. ".json", -- Also export JSON data
-                    dataFormat = "json-hash",
-                    borderPadding = 0,
-                    shapePadding = 0,
-                    innerPadding = 0,
-                    trimSprite = data.trimSprite,
-                    trim = data.trimCells,
-                    trimByGrid = data.trimByGrid,
-                    layer = layer.name, -- Export only the current layer
-                    splitLayers = false,
-                    splitTags = (data.tagsplit ~= "No") -- Use original tag splitting logic here if needed
-                }
-                n_files_exported = n_files_exported + 1
-            end
-
+            
+            performExportForLayer(sprite, layer, current_filename_template, data)
+            
             layer.isVisible = false
         end
     end
@@ -101,40 +106,39 @@ end
 -- ## DIALOG ##
 -- ############
 
+-- First, get a flat list of all layers to build the UI
+local flat_layers = getAllLayers(Sprite)
 local dlg = Dialog("Pepeups - Export by Layer and Tag")
-dlg:file{
-    id = "directory",
-    label = "Output directory:",
-    filename = Sprite.filename,
-    open = false
-}
-dlg:entry{
-    id = "filename",
-    label = "File name format:",
-    text = "{layergroups}{layername}-{tag}" -- Added {tag}
-}
+
 dlg:combobox{
-    id = 'format',
-    label = 'Export Format:',
-    option = 'png',
-    options = {'png', 'gif', 'jpg'}
+    id = "exportMode",
+    label = "Export:",
+    options = {"All Layers", "Selected Layers"},
+    selected = "All Layers",
+    onchange = function()
+        -- Modify visibility of all checkboxes, the label and separator line
+        local is_selection_mode = (dlg.data.exportMode == "Selected Layers")
+        dlg:modify{id="layerSelectionSeparator", visible = is_selection_mode}
+        dlg:modify{id="layerSelectionLabel", visible = is_selection_mode}
+        for i=1, #flat_layers do
+            dlg:modify{id="export_layer_" .. i, visible = is_selection_mode}
+        end
+    end
 }
-dlg:combobox{
-    id = 'group_sep',
-    label = 'Group separator:',
-    option = Sep,
-    options = {Sep, '-', '_'}
-}
+dlg:separator()
+
+dlg:file{ id = "directory", label = "Output directory:", filename = Sprite.filename, open = false }
+dlg:entry{ id = "filename", label = "File name format:", text = "{layergroups}{layername}-{tag}" }
+dlg:combobox{ id = 'format', label = 'Export Format:', option = 'png', options = {'png', 'gif', 'jpg'} }
+dlg:combobox{ id = 'group_sep', label = 'Group separator:', option = Sep, options = {Sep, '-', '_'} }
 dlg:slider{id = 'scale', label = 'Export Scale:', min = 1, max = 10, value = 1}
 dlg:separator()
 
--- ## TAGS OPTION ##
 dlg:check{
     id = "splitByTagFile",
     label = "Export each tag as a separate file",
     selected = true,
     onclick = function()
-        -- Toggle visibility of conflicting options
         dlg:modify{ id = "tagsplit", visible = not dlg.data.splitByTagFile }
         local new_filename_text = dlg.data.filename
         if dlg.data.splitByTagFile then
@@ -149,20 +153,35 @@ dlg:check{
 }
 
 dlg:separator()
--- Options for spritesheet trimming
 dlg:check{ id = "trimSprite", label = "Trim Sprite:", selected = false }
 dlg:check{ id = "trimCells", label = "Trim Cells:", selected = false }
 dlg:check{ id = "trimByGrid", label = "Trim By Grid:", selected = false }
 
--- This option is for layout, conflicts with splitting by file
 dlg:combobox{
     id = "tagsplit",
     label = "Split Tags (Layout):",
-    visible = false, -- Hide by default since "splitByTagFile" is true
+    visible = false,
     option = 'No',
     options = {'No', 'To Rows', 'To Columns'}
 }
 
+-- Use a label instead of a section
+dlg:separator{id="layerSelectionSeparator", visible=false}
+dlg:label{id = "layerSelectionLabel", text = "Select Layers to Export:", visible = false}
+
+for i, item in ipairs(flat_layers) do
+    dlg:check{
+        id = "export_layer_" .. i,
+        text = item.displayName,
+        selected = true,
+        visible = false -- Start hidden, will be shown by the combobox onchange event
+    }
+    if i % 3 == 0 then -- New row every 3 layers
+        dlg:newrow()
+    end
+end
+
+dlg:separator()
 dlg:check{id = "save", label = "Save sprite:", selected = false}
 dlg:button{id = "ok", text = "Export"}
 dlg:button{id = "cancel", text = "Cancel"}
@@ -174,33 +193,30 @@ if not dlg.data.ok then return 0 end
 -- ## EXECUTION LOGIC ##
 -- ####################
 
--- Get path and filename
 local output_path = Dirname(dlg.data.directory)
-local filename_template = dlg.data.filename .. "." .. dlg.data.format
-
 if output_path == nil then
     local err_dlg = MsgDialog("Error", "No output directory was specified.")
     err_dlg:show()
     return 1
 end
 
+local filename_template = dlg.data.filename .. "." .. dlg.data.format
 local group_sep = dlg.data.group_sep
 filename_template = filename_template:gsub("{spritename}", RemoveExtension(Basename(Sprite.filename)))
-filename_template = filename_template:gsub("{groupseparator}", group_sep)
 
--- Perform everything.
+-- Perform everything!
 Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
 local layers_visibility_data = HideLayers(Sprite)
 
-exportByLayerAndTag(Sprite, Sprite, output_path .. filename_template, group_sep, dlg.data)
+processAndExportLayers(Sprite, output_path .. filename_template, group_sep, dlg.data, flat_layers)
 
 RestoreLayersVisibility(Sprite, layers_visibility_data)
 Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
 
--- Save the original file if specified
+-- Save Sprite
 if dlg.data.save then Sprite:saveAs(dlg.data.directory) end
 
--- Success dialog.
+-- Success Dialogue
 local success_dlg = MsgDialog("Success!", "Exported " .. n_files_exported .. " files.")
 success_dlg:show()
 

--- a/scripts/gaspi/export_by_layer_and_tag.lua
+++ b/scripts/gaspi/export_by_layer_and_tag.lua
@@ -1,0 +1,203 @@
+--[[
+Description:
+A script to save all different layers in different files, with an option
+to further split each layer's export into separate files for each tag.
+
+Based on the original script by Gaspi.
+Extended to support per-tag file splitting.
+
+Made by Pedro Vilas Bôas.
+   - Itch.io: https://pedrovilasboas.itch.io/
+   - Twitter: @pepeups
+
+   Further Contributors:
+    - Gaspi ("_Gaspi")
+    - Levy E ("StoneLabs")
+    - David Höchtl ("DavidHoechtl")
+    - Demonkiller8973
+--]]
+
+-- Import main.
+local err = dofile("main.lua")
+if err ~= 0 then return err end
+
+-- Variable to keep track of the number of files exported.
+local n_files_exported = 0
+
+-- Exports every layer individually, with an option to split by tag.
+local function exportByLayerAndTag(sprite, root_layer, filename_template, group_sep, data)
+    for _, layer in ipairs(root_layer.layers) do
+        local current_filename_template = filename_template
+        if layer.isGroup then
+            -- Recursive for groups.
+            local previousVisibility = layer.isVisible
+            layer.isVisible = true
+            current_filename_template = current_filename_template:gsub("{layergroups}",
+                                           layer.name .. group_sep .. "{layergroups}")
+            exportByLayerAndTag(sprite, layer, current_filename_template, group_sep, data)
+            layer.isVisible = previousVisibility
+        else
+            -- Individual layer. Export it.
+            layer.isVisible = true
+            current_filename_template = current_filename_template:gsub("{layergroups}", "")
+            current_filename_template = current_filename_template:gsub("{layername}", layer.name)
+
+            if data.splitByTagFile and #sprite.tags > 0 then
+                -- ## NEW LOGIC: Iterate through each tag and export a file for it. ##
+                for _, tag in ipairs(sprite.tags) do
+                    local final_filename = current_filename_template:gsub("{tag}", tag.name)
+                    os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
+
+                    app.command.ExportSpriteSheet{
+                        ui = false,
+                        askOverwrite = false,
+                        type = SpriteSheetType.HORIZONTAL, -- Or ROWS, COLUMNS as per your preference
+                        textureFilename = final_filename,
+                        dataFilename = "", -- No JSON data for this simple export
+                        borderPadding = 0,
+                        shapePadding = 0,
+                        innerPadding = 0,
+                        trimSprite = data.trimSprite,
+                        trim = data.trimCells,
+                        trimByGrid = data.trimByGrid,
+                        layer = layer.name, -- Export only the current layer
+                        tag = tag.name,     -- Export only the current tag
+                        splitLayers = false, -- We are handling layers manually
+                        splitTags = false    -- We are handling tags manually
+                    }
+                    n_files_exported = n_files_exported + 1
+                end
+            else
+                -- ## OLD LOGIC: Export the whole layer as one file. ##
+                local final_filename = current_filename_template:gsub("{tag}", "") -- Remove tag placeholder if not used
+                os.execute("mkdir \"" .. Dirname(final_filename) .. "\"")
+                app.command.ExportSpriteSheet{
+                    ui=false,
+                    askOverwrite=false,
+                    type=SpriteSheetType.ROWS, -- Default to rows for non-tag-split
+                    textureFilename = final_filename,
+                    dataFilename = RemoveExtension(final_filename) .. ".json", -- Also export JSON data
+                    dataFormat = "json-hash",
+                    borderPadding = 0,
+                    shapePadding = 0,
+                    innerPadding = 0,
+                    trimSprite = data.trimSprite,
+                    trim = data.trimCells,
+                    trimByGrid = data.trimByGrid,
+                    layer = layer.name, -- Export only the current layer
+                    splitLayers = false,
+                    splitTags = (data.tagsplit ~= "No") -- Use original tag splitting logic here if needed
+                }
+                n_files_exported = n_files_exported + 1
+            end
+
+            layer.isVisible = false
+        end
+    end
+end
+
+
+-- ############
+-- ## DIALOG ##
+-- ############
+
+local dlg = Dialog("Export by Layer and Tag")
+dlg:file{
+    id = "directory",
+    label = "Output directory:",
+    filename = Sprite.filename,
+    open = false
+}
+dlg:entry{
+    id = "filename",
+    label = "File name format:",
+    text = "{layergroups}{layername}-{tag}" -- Added {tag}
+}
+dlg:combobox{
+    id = 'format',
+    label = 'Export Format:',
+    option = 'png',
+    options = {'png', 'gif', 'jpg'}
+}
+dlg:combobox{
+    id = 'group_sep',
+    label = 'Group separator:',
+    option = Sep,
+    options = {Sep, '-', '_'}
+}
+dlg:slider{id = 'scale', label = 'Export Scale:', min = 1, max = 10, value = 1}
+dlg:separator()
+
+-- ## NEW OPTION ##
+dlg:check{
+    id = "splitByTagFile",
+    label = "Export each tag as a separate file",
+    selected = true,
+    onclick = function()
+        -- Toggle visibility of conflicting options
+        dlg:modify{ id = "tagsplit", visible = not dlg.data.splitByTagFile }
+        local new_filename_text = dlg.data.filename
+        if dlg.data.splitByTagFile then
+            if not new_filename_text:find("{tag}") then
+                new_filename_text = new_filename_text .. "-{tag}"
+            end
+        else
+            new_filename_text = new_filename_text:gsub("-{tag}", ""):gsub("{tag}", "")
+        end
+        dlg:modify{id = "filename", text = new_filename_text}
+    end
+}
+
+dlg:separator()
+-- Options for spritesheet trimming
+dlg:check{ id = "trimSprite", label = "Trim Sprite:", selected = false }
+dlg:check{ id = "trimCells", label = "Trim Cells:", selected = false }
+dlg:check{ id = "trimByGrid", label = "Trim By Grid:", selected = false }
+
+-- This option is for layout, conflicts with splitting by file
+dlg:combobox{
+    id = "tagsplit",
+    label = "Split Tags (Layout):",
+    visible = false, -- Hide by default since "splitByTagFile" is true
+    option = 'No',
+    options = {'No', 'To Rows', 'To Columns'}
+}
+
+dlg:button{id = "ok", text = "Export"}
+dlg:button{id = "cancel", text = "Cancel"}
+dlg:show()
+
+if not dlg.data.ok then return 0 end
+
+-- ####################
+-- ## EXECUTION LOGIC ##
+-- ####################
+
+-- Get path and filename
+local output_path = Dirname(dlg.data.directory)
+local filename_template = dlg.data.filename .. "." .. dlg.data.format
+
+if output_path == nil then
+    local err_dlg = MsgDialog("Error", "No output directory was specified.")
+    err_dlg:show()
+    return 1
+end
+
+local group_sep = dlg.data.group_sep
+filename_template = filename_template:gsub("{spritename}", RemoveExtension(Basename(Sprite.filename)))
+filename_template = filename_template:gsub("{groupseparator}", group_sep)
+
+-- Perform everything.
+Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
+local layers_visibility_data = HideLayers(Sprite)
+
+exportByLayerAndTag(Sprite, Sprite, output_path .. filename_template, group_sep, dlg.data)
+
+RestoreLayersVisibility(Sprite, layers_visibility_data)
+Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+
+-- Success dialog.
+local success_dlg = MsgDialog("Success!", "Exported " .. n_files_exported .. " files.")
+success_dlg:show()
+
+return 0

--- a/scripts/gaspi/main.lua
+++ b/scripts/gaspi/main.lua
@@ -113,6 +113,8 @@ if debug.getinfo(2) == nil then
    dlg:newrow()
    dlg:button{id = "layers", text = "Export layers", onclick = function() dofile("export_layers.lua") end}
    dlg:newrow()
+   dlg:button{id = "layer_and_tag", text = "Export Layers by Tag", onclick = function() dofile("export_by_layer_and_tag.lua") end}
+   dlg:newrow()
    dlg:button{id = "slices", text = "Export slices", onclick = function() dofile("export_slices.lua") end}
    dlg:newrow()
    dlg:button{id = "combinations", text = "Export combinations", onclick = function() dofile("export_combinations.lua") end}


### PR DESCRIPTION
### Summary

Introduces a new export script, `export_by_layer_and_tag.lua`, to support advanced animation workflows.

### Motivation

The existing `export_layers.lua` script is useful for separating a sprite's layers into individual files. However, it doesn't address the next step in many development pipelines: separating the animations within those layers. For modular characters (e.g., swapping hairstyles, armor, etc.), developers often need each animation state (e.g., "run", "idle", "attack") for each layer as a separate file. This PR automates that entire process.

### Implementation

This pull request introduces `export_by_layer_and_tag.lua`, a new script that:
- Iterates through each layer in the sprite.
- Performs a nested loop through each animation tag.
- Exports a unique spritesheet file for every layer-tag pair, using a filename format like ``{layername}-{tag}.png``.