### PR TITLE
Detects and skips layers with true `isReference` flag.

### DIFF
--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -56,6 +56,11 @@ local function exportLayers(sprite, root_layer, filename, group_sep, data)
             exportLayers(sprite, layer, filename, group_sep, data)
             layer.isVisible = previousVisibility
         else
+            -- Ignore reference layers.
+            if layer.isReference then
+                goto continue
+            end
+
             -- Individual layer. Export it.
             layer.isVisible = true
             filename = filename:gsub("{layergroups}", "")
@@ -121,6 +126,7 @@ local function exportLayers(sprite, root_layer, filename, group_sep, data)
             layer.isVisible = false
             n_layers = n_layers + 1
         end
+        ::continue::
     end
 end
 


### PR DESCRIPTION
Reference layers are exported as blank files. Simply adding an early return if the `isReference` flag is true fixes this entirely.

![showcase](https://github.com/user-attachments/assets/92778b4f-b1d6-4c58-b52b-0ea53576db14)
