### PR TITLE
Utilise transactions to keep preserve history

### DIFF
--- a/scripts/gaspi/export_combinations.lua
+++ b/scripts/gaspi/export_combinations.lua
@@ -92,12 +92,16 @@ filename = filename:gsub("{spritename}",
 filename = filename .. '.' .. dlg.data.format
 
 
--- Finally, perform everything.
-Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
-local layers_visibility_data = HideLayers(Sprite)
-exportCombinations(Sprite, Sprite.layers, output_path .. filename)
-RestoreLayersVisibility(Sprite, layers_visibility_data)
-Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+-- Finally, perform everything, maintaining 1 transaction
+app.transaction("Export Combinations", function()
+    Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
+    local layers_visibility_data = HideLayers(Sprite)
+    exportCombinations(Sprite, Sprite.layers, output_path .. filename)
+    RestoreLayersVisibility(Sprite, layers_visibility_data)
+    Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+end)
+-- Undo the transaction to revert history to before exporting
+app.undo() 
 
 -- Save the original file if specified
 if dlg.data.save then Sprite:saveAs(dlg.data.directory) end

--- a/scripts/gaspi/export_layers.lua
+++ b/scripts/gaspi/export_layers.lua
@@ -277,12 +277,16 @@ filename = filename:gsub("{spritename}",
                          RemoveExtension(Basename(Sprite.filename)))
 filename = filename:gsub("{groupseparator}", group_sep)
 
--- Finally, perform everything.
-Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
-local layers_visibility_data = HideLayers(Sprite)
-exportLayers(Sprite, Sprite, output_path .. filename, group_sep, dlg.data)
-RestoreLayersVisibility(Sprite, layers_visibility_data)
-Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+-- Finally, perform everything, maintaining 1 transaction
+app.transaction("Export Layers", function()
+    Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
+    local layers_visibility_data = HideLayers(Sprite)
+    exportLayers(Sprite, Sprite, output_path .. filename, group_sep, dlg.data)
+    RestoreLayersVisibility(Sprite, layers_visibility_data)
+    Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+end)
+-- Undo the transaction to revert history to before exporting
+app.undo() 
 
 -- Save the original file if specified
 if dlg.data.save then Sprite:saveAs(dlg.data.directory) end

--- a/scripts/gaspi/export_slices.lua
+++ b/scripts/gaspi/export_slices.lua
@@ -69,47 +69,52 @@ end
 filename = filename:gsub("{spritename}",
                          RemoveExtension(Basename(Sprite.filename)))
 
--- Save original bounds to restore later.
-Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
-local og_bounds = Sprite.bounds
+-- Maintain 1 transaction
+app.transaction("Export Slices", function()
+    -- Save original bounds to restore later.
+    Sprite:resize(Sprite.width * dlg.data.scale, Sprite.height * dlg.data.scale)
+    local og_bounds = Sprite.bounds
 
--- Count how many times a slice with the same name and group exist.
-local slice_count = {}
-for _, slice in ipairs(Sprite.slices) do
-    local slice_id = slice.data .. Sep .. slice.name
-    if slice_count[slice_id] == nil then
-        slice_count[slice_id] = 1
-    else
-        slice_count[slice_id] = slice_count[slice_id] + 1
-    end
-end
-
--- Export slices.
-for _, slice in ipairs(Sprite.slices) do
-    -- Keep track of the origin offset.
-    og_bounds.x = og_bounds.x - slice.bounds.x
-    og_bounds.y = og_bounds.y - slice.bounds.y
-
-    -- Crop the sprite to this slice's size and position.
-    Sprite:crop(slice.bounds)
-
-    -- Save the cropped sprite.
-    local slice_id = slice.data .. Sep .. slice.name
-    local slice_filename = filename:gsub("{slicename}", slice.name)
-    slice_filename = slice_filename:gsub("{slicedata}", slice.data)
-    if slice_count[slice_id] > 1 then
-        slice_filename = slice_filename .. "_" .. slice_count[slice_id]
+    -- Count how many times a slice with the same name and group exist.
+    local slice_count = {}
+    for _, slice in ipairs(Sprite.slices) do
+        local slice_id = slice.data .. Sep .. slice.name
+        if slice_count[slice_id] == nil then
+            slice_count[slice_id] = 1
+        else
+            slice_count[slice_id] = slice_count[slice_id] + 1
+        end
     end
 
-    -- Create output dir in case it doesn't exist.
-    os.execute("mkdir \"" .. Dirname(output_path .. slice_filename) .. "\"")
-    slice_count[slice_id] = slice_count[slice_id] - 1
-    Sprite:saveCopyAs(output_path .. slice_filename)
-end
+    -- Export slices.
+    for _, slice in ipairs(Sprite.slices) do
+        -- Keep track of the origin offset.
+        og_bounds.x = og_bounds.x - slice.bounds.x
+        og_bounds.y = og_bounds.y - slice.bounds.y
 
--- Restore original bounds.
-Sprite:crop(og_bounds)
-Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+        -- Crop the sprite to this slice's size and position.
+        Sprite:crop(slice.bounds)
+
+        -- Save the cropped sprite.
+        local slice_id = slice.data .. Sep .. slice.name
+        local slice_filename = filename:gsub("{slicename}", slice.name)
+        slice_filename = slice_filename:gsub("{slicedata}", slice.data)
+        if slice_count[slice_id] > 1 then
+            slice_filename = slice_filename .. "_" .. slice_count[slice_id]
+        end
+
+        -- Create output dir in case it doesn't exist.
+        os.execute("mkdir \"" .. Dirname(output_path .. slice_filename) .. "\"")
+        slice_count[slice_id] = slice_count[slice_id] - 1
+        Sprite:saveCopyAs(output_path .. slice_filename)
+    end
+
+    -- Restore original bounds.
+    Sprite:crop(og_bounds)
+    Sprite:resize(Sprite.width / dlg.data.scale, Sprite.height / dlg.data.scale)
+end)
+-- Undo the transaction to revert history to before exporting
+app.undo() 
 
 -- Save the original file if specified
 if dlg.data.save then Sprite:saveAs(dlg.data.directory) end


### PR DESCRIPTION
Thanks so much for publishing this script. It has made it really easy to keep my textures organised in 1 file and export them all at once. However, every time I would use it, it would fuck up my entire undo history. This PR is to resolve that.

In all 3 scripts, I utilised a transaction that bundles all edits together, and undoes them at the end. That way, the user's edit history is preserved, and it's restored to the state it was before running the script. This way, you can quickly go back and revert changes made before the export, without having to sit through hundreds of crops.

| Before | After |
| :--- | :--- |
| <img width="271" height="277" src="https://github.com/user-attachments/assets/2f885443-af1f-49f1-bb5e-364a4bfb637d" /> | <img width="220" height="221" src="https://github.com/user-attachments/assets/7ca49f20-6c29-4135-bb26-2248a85a420d" /> |

The diffs show a lot of changed lines, but in reality I only added such wrappers:
```lua
-- Finally, perform everything, maintaining 1 transaction
app.transaction("Export Slices", function()
  -- ...
end)
-- Undo the transaction to revert history to before exporting
app.undo() 
```